### PR TITLE
Fix typos in 01-sets_and_functions.Rmd

### DIFF
--- a/01-sets_and_functions.Rmd
+++ b/01-sets_and_functions.Rmd
@@ -69,7 +69,7 @@ There are some important sets which have their own symbols and names. You have p
 
 ::: {.definition name="equality of sets/axiom of extension"}
 
-Two sets are equal (the same) if they have exactly the same elements. We call this the axiom of extension. We can write it in formal language as: if for every \(x \in A\) we have \(x \in B\) and for every \(y \in B\) we have \(y \in B\) then \(A=B\).
+Two sets are equal (the same) if they have exactly the same elements. We call this the axiom of extension. We can write it in formal language as: if for every \(x \in A\) we have \(x \in B\) and for every \(y \in B\) we have \(y \in A\) then \(A=B\).
 
 :::
 
@@ -294,7 +294,7 @@ Given a function \(f:A \rightarrow B\) then
 
 - If \(C \subset A\) we write \(f(C) = \{y \in B \,:\, y = f(x) \, \mbox{for some} \, x \in C\}\). We call \(f(C)\) the *image* of \(C\) under \(f\).
 
-- If \(D \in B\) we write \(f^{-1}(D)) = \{ x \in C \,:\, f(x) \in D\}\). We call \(f^{-1}(D)\) the *pre-image* of \(D\) under \(f\).
+- If \(D \in B\) we write \(f^{-1}(D) = \{ x \in C \,:\, f(x) \in D\}\). We call \(f^{-1}(D)\) the *pre-image* of \(D\) under \(f\).
 
 :::
 

--- a/_book/sets-and-functions.html
+++ b/_book/sets-and-functions.html
@@ -206,7 +206,7 @@ set in the _output.yml file.</p>" />
 </ul>
 </div>
 <div class="definition">
-<p><span id="def:unlabeled-div-7" class="definition"><strong>Definition 2.3  (equality of sets/axiom of extension) </strong></span>Two sets are equal (the same) if they have exactly the same elements. We call this the axiom of extension. We can write it in formal language as: if for every <span class="math inline">\(x \in A\)</span> we have <span class="math inline">\(x \in B\)</span> and for every <span class="math inline">\(y \in B\)</span> we have <span class="math inline">\(y \in B\)</span> then <span class="math inline">\(A=B\)</span>.</p>
+<p><span id="def:unlabeled-div-7" class="definition"><strong>Definition 2.3  (equality of sets/axiom of extension) </strong></span>Two sets are equal (the same) if they have exactly the same elements. We call this the axiom of extension. We can write it in formal language as: if for every <span class="math inline">\(x \in A\)</span> we have <span class="math inline">\(x \in B\)</span> and for every <span class="math inline">\(y \in B\)</span> we have <span class="math inline">\(y \in A\)</span> then <span class="math inline">\(A=B\)</span>.</p>
 </div>
 <div class="remark">
 <p><span id="unlabeled-div-8" class="remark"><em>Remark</em>. </span>It might seem obvious at this point that any two sets with the same element are the same. However there are two important ways this comes up.</p>
@@ -338,7 +338,7 @@ Figure 2.1: Picture showing A as a subset of B with sets indicated by circles
 <p><span id="def:unlabeled-div-32" class="definition"><strong>Definition 2.16  (image and pre-image) </strong></span>Given a function <span class="math inline">\(f:A \rightarrow B\)</span> then</p>
 <ul>
 <li><p>If <span class="math inline">\(C \subset A\)</span> we write <span class="math inline">\(f(C) = \{y \in B \,:\, y = f(x) \, \mbox{for some} \, x \in C\}\)</span>. We call <span class="math inline">\(f(C)\)</span> the <em>image</em> of <span class="math inline">\(C\)</span> under <span class="math inline">\(f\)</span>.</p></li>
-<li><p>If <span class="math inline">\(D \in B\)</span> we write <span class="math inline">\(f^{-1}(D)) = \{ x \in C \,:\, f(x) \in D\}\)</span>. We call <span class="math inline">\(f^{-1}(D)\)</span> the <em>pre-image</em> of <span class="math inline">\(D\)</span> under <span class="math inline">\(f\)</span>.</p></li>
+<li><p>If <span class="math inline">\(D \in B\)</span> we write <span class="math inline">\(f^{-1}(D) = \{ x \in C \,:\, f(x) \in D\}\)</span>. We call <span class="math inline">\(f^{-1}(D)\)</span> the <em>pre-image</em> of <span class="math inline">\(D\)</span> under <span class="math inline">\(f\)</span>.</p></li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
Just fixed some minor typos in `01-sets_and_functions.Rmd`. I also manually updated the HTML in `_book/` since Rstudio is new to me and I couldn't rebuild the book that way without it changing almost every file.